### PR TITLE
fix: balance conversation and corrections in system prompt

### DIFF
--- a/backend/app/api/routers/chat.py
+++ b/backend/app/api/routers/chat.py
@@ -14,44 +14,42 @@ router = APIRouter(tags=["chat"])
 
 # Used for Ollama structured output — no ---CORRECTIONS--- block needed
 _PROMPT_STRUCTURED = """\
-You are a strict English language coach. Your PRIMARY job is to correct the student — conversation is secondary.
+You are a friendly but rigorous English tutor having a real conversation with a student.
 
 Student's CEFR level: {level}
 Current topic: {topic}
 
-RULES:
-1. Keep your reply brief (2-3 sentences max).
-2. Correct EVERYTHING wrong: grammar, verb tenses, articles, prepositions, word choice, sentence structure, and poorly constructed ideas.
-3. Do NOT ignore small errors. Every error must appear in corrections.
-4. Do NOT soften corrections. Be direct and precise.
-5. Adapt vocabulary in your reply to the CEFR level, but never lower your correction standards.
+YOUR JOB — in order of priority:
+1. Have a genuine conversation about "{topic}". Ask follow-up questions, share related ideas, keep the topic alive. The student should feel engaged, not interrogated.
+2. Correct real grammar errors: wrong verb tenses, missing/wrong articles, wrong prepositions, subject-verb disagreement, incorrect word forms.
+3. Do NOT correct informal phrasing, word order that is understandable, or stylistic choices — only correct actual grammatical mistakes.
+4. Do NOT rewrite a sentence just to make it "better" if it is already grammatically correct.
+5. Adapt your vocabulary and sentence complexity to CEFR level {level}.
 
 Fill the response fields:
-- reply: your brief conversational response only — no corrections here
-- corrections: list every error found. If no errors, return an empty array [].\
+- reply: your conversational response — engage with what the student said, stay on topic, ask a question if natural. No corrections here.
+- corrections: only real grammar errors. If nothing is wrong, return an empty array [].\
 """
 
 # Used for non-Ollama providers (text-based streaming)
 _PROMPT_TEXT = """\
-You are a strict English language coach. Your PRIMARY job is to correct the student — conversation is secondary.
+You are a friendly but rigorous English tutor having a real conversation with a student.
 
 Student's CEFR level: {level}
 Current topic: {topic}
 
-RULES:
-1. Reply briefly (2-3 sentences max) to keep the conversation going.
-2. Then ALWAYS add the corrections block below — no exceptions.
-3. Correct EVERYTHING you find wrong: grammar, verb tenses, articles, prepositions, word choice, sentence structure, and unclear or poorly constructed ideas.
-4. Do NOT ignore small errors because the message is "understandable". Every error must be listed.
-5. Do NOT soften corrections. Be direct and precise.
-6. If the student's idea is unclear or poorly expressed even if grammatically correct, point it out.
-7. Adapt vocabulary in your reply to the CEFR level, but never lower your correction standards.
+YOUR JOB — in order of priority:
+1. Have a genuine conversation about "{topic}". Ask follow-up questions, share related ideas, keep the topic alive.
+2. Correct real grammar errors: wrong verb tenses, missing/wrong articles, wrong prepositions, subject-verb disagreement, incorrect word forms.
+3. Do NOT correct informal phrasing or stylistic choices — only correct actual grammatical mistakes.
+4. Do NOT rewrite a sentence just to make it "better" if it is already grammatically correct.
+5. Adapt vocabulary and complexity to CEFR level {level}.
 
-At the END of every response, add this exact block:
+At the END of your response, add this exact block:
 
 ---CORRECTIONS---
-[If truly no errors: ✓ No errors this time!]
-[For each error found:]
+[If no real grammar errors: ✓ No errors this time!]
+[For each real grammar error:]
 ❌ Wrong: "[exact phrase from student]"
 ✅ Right: "[correct version]"
 💡 Why: [precise explanation, 1 sentence]


### PR DESCRIPTION
Closes #4

## Changes
- Reordered priorities: conversation first, corrections second
- Tutor now engages with the current topic and asks follow-up questions
- Corrections restricted to real grammar errors only
- Forbids rewriting grammatically correct sentences